### PR TITLE
chore: update `elevationRequirement` for `spicetify`

### DIFF
--- a/manifests/s/Spicetify/Spicetify/2.39.5/Spicetify.Spicetify.installer.yaml
+++ b/manifests/s/Spicetify/Spicetify/2.39.5/Spicetify.Spicetify.installer.yaml
@@ -4,6 +4,7 @@
 PackageIdentifier: Spicetify.Spicetify
 PackageVersion: 2.39.5
 InstallerType: zip
+ElevationRequirement: elevationProhibited
 NestedInstallerType: portable
 NestedInstallerFiles:
 - RelativeFilePath: spicetify.exe


### PR DESCRIPTION
Checklist for Pull Requests
- [x] Have you signed the [Contributor License Agreement](https://cla.opensource.microsoft.com/microsoft/winget-pkgs)?
- [ ] Is there a linked Issue?

Manifests
- [x] Have you checked that there aren't other open [pull requests](https://github.com/microsoft/winget-pkgs/pulls) for the same manifest update/change?
- [x] This PR only modifies one (1) manifest
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.9 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.9.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

This change is needed to address some issues we've been having with users running it with elevated permissions and this addresses that. Future releases should automatically have this change picked up by komac.